### PR TITLE
completing the implementation of the size of the highpass filter

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,8 @@ default_test_modules = ['emva1288.unittests.test_coding_standards',
                         'emva1288.unittests.test_loader.TestLoader',
                         'emva1288.unittests.test_data.TestData',
                         'emva1288.unittests.test_results.TestResults',
-                        'emva1288.unittests.test_report.TestReportGenerator']
+                        'emva1288.unittests.test_report.TestReportGenerator',
+                        'emva1288.unittests.test_results.TestRoutines']
 
 
 def run():


### PR DESCRIPTION
There was an error in the hight_pass_filter function. It was possible to specify the kernel size, but if you put anything other than 5 while using a bayer filter, it would fail (see line 631). Furthermore, the returned image would be invalid for any image filtered with a kernel size greater than 5, since the slice at the end was not adapted to the dim argument.

This pull request corrects the bugs. It has been tested both on a generated idataset from emva1288.examples and on a local sample, to assert the result for a kernel size of 5 remains the same. 

Finally, we verify that the dimension argument is odd, since the kernel size must be odd for the filter to work.