### PR TITLE
added hpf to images used for spatial variance calc

### DIFF
--- a/emva1288/process/data.py
+++ b/emva1288/process/data.py
@@ -15,6 +15,7 @@ etc...) without loosing accuracy.
 
 import numpy as np
 import logging
+from emva1288.process import routines
 
 
 class Data1288(object):
@@ -288,11 +289,17 @@ class Data1288(object):
         avg_ = sum_ / (1.0 * L)
         var_ = pvar_ / (1.0 * np.square(L) * (L - 1))
 
+        # hpf avg image to use as avg_var
+        hpf_dict = routines.high_pass_filter(avg_, 5)
+        avg_hpf = hpf_dict['img'] / hpf_dict['multiplicator']
+        # correct for std reduction from hpf
+        avg_var = (np.std(avg_hpf, ddof=1) / 0.96)**2
+
         return {'sum' + postfix: sum_,
                 'var_mean' + postfix: var_.mean(),
                 'L' + postfix: L,
                 # ddof = 1 (delta degrees of freedom) accounts for the minus 1
                 # in the divisor for the calculation of variance
-                'avg_var' + postfix: np.var(avg_, ddof=1),
+                'avg_var' + postfix: avg_var,
                 'avg_mean' + postfix: avg_.mean()
                 }

--- a/emva1288/process/data.py
+++ b/emva1288/process/data.py
@@ -292,6 +292,7 @@ class Data1288(object):
         # hpf avg image to use as avg_var
         hpf_dict = routines.high_pass_filter(avg_, 5)
         avg_hpf = hpf_dict['img'] / hpf_dict['multiplicator']
+
         # correct for std reduction from hpf
         avg_var = (np.std(avg_hpf, ddof=1) / 0.96)**2
 


### PR DESCRIPTION
Included high pass filtering of images used for spatial variance calculation to satisfy the following from Section C.3 from EMVA1288 Release 3.1:

"For a proper analysis of defect pixels, a highpass filtering is introduced so that the PRNU
measurements are not spoiled by the imperfections of the used light source (Section 4.4).
This highpass filtering is used also before all other nonuniformity evaluations including the estimation of spatial variances (Section 8.1) except for the computation of the
spectrograms and all quantities derived from them (Section 8.2)"

Also corrected the standard deviation from the resulting hpf based on Section C.5:

"For the proposed 5 × 5 box filter (P = 5), the reduction in the standard deviation is just 4%: σy0 = 0.96 σy.
Therefore the measured spatial standard deviation sy0 must be divided by 0.96 in order to
obtain the correct value."