### PR TITLE
__init__ and matplotlib fix

### DIFF
--- a/emva1288/__init__.py
+++ b/emva1288/__init__.py
@@ -1,1 +1,0 @@
-from ._version import version as __version__

--- a/emva1288/process/plotting.py
+++ b/emva1288/process/plotting.py
@@ -869,5 +869,5 @@ class Plotting1288(object):
             for test in self.tests:
                 plot.plot(test)
             plot.rearrange()
-            figure.canvas.set_window_title(plot.name)
+            figure.canvas.manager.set_window_title(plot.name)
         plt.show()


### PR DESCRIPTION
__init__ was referencing a non existing _version module.

Modified matplotlib title to suppress warning:
\emva1288\emva1288\process\plotting.py:872: MatplotlibDeprecationWarning:
The set_window_title function was deprecated in Matplotlib 3.4 and will be removed two minor releases later. Use manager.set_window_title or GUI-specific methods instead.
  figure.canvas.set_window_title(plot.name)