### PR TITLE
Fix wrong slicing of a list of 1 dim ndarrays

### DIFF
--- a/emva1288/process/routines.py
+++ b/emva1288/process/routines.py
@@ -119,7 +119,7 @@ def GetImgShape(img):
     return rows, cols
 
 
-def FFT1288(img_, rotate=False, n=1):
+def FFT1288(img, rotate=False, n=1):
     '''Compute the FFT emva1288 style
 
     Compute an FFT per line and average the resulting ffts
@@ -142,35 +142,14 @@ def FFT1288(img_, rotate=False, n=1):
     -------
     array : One dimension FFT power spectrum
     '''
-    img = img_.copy()
     if rotate:
         img = img.transpose()
 
-    _rows, cols = GetImgShape(img)
-
     # remove masked entries if img is a masked array
     if isinstance(img, np.ma.masked_array):
-        # use the same ndarray to save memory
-        compressed = np.ma.getdata(img)
-        # the maximum numbers or cols is the shape
-        cols = compressed.shape[1]
-        # keep count of non empty lines
-        lines = 0
-        # compress line by line
-        for line in img:
-            # drop masked data
-            line = line.compressed()
-            # assure the line is not empty
-            if line.size == 0:
-                continue
-            # set the data in the compressed array
-            compressed[lines, :line.size] = line
-            # keep count of non-empty lines
-            lines += 1
-            # keep trac of minimum column size
-            cols = min(cols, line.size)
-        # trim to actual number of lines and columns
-        img = compressed[:lines, :cols]
+        img = _row_wise_compress(img)
+
+    _rows, cols = GetImgShape(img)
 
     # simply perform fft on x axis
     img = np.asfarray(img) - np.mean(img)
@@ -187,6 +166,36 @@ def FFT1288(img_, rotate=False, n=1):
 
     # Return only half of the spectrogram (it is symemtrical)
     return r[: cols // 2]
+
+
+def _row_wise_compress(img):
+    """ Compress masked ndarrays row-by-row
+
+    Empty (fully masked) rows are removed. The number of columns is truncated to the row with the least amount
+    of valid entries.
+    """
+    img = img.copy()
+    # use the same ndarray to save memory
+    compressed = np.ma.getdata(img)
+    # the maximum numbers or cols is the shape
+    cols = compressed.shape[1]
+    # keep count of non empty lines
+    lines = 0
+    # compress line by line
+    for line in img:
+        # drop masked data
+        line = line.compressed()
+        # assure the line is not empty
+        if line.size == 0:
+            continue
+        # set the data in the compressed array
+        compressed[lines, :line.size] = line
+        # keep count of non-empty lines
+        lines += 1
+        # keep trac of minimum column size
+        cols = min(cols, line.size)
+    # trim to actual number of lines and columns
+    return compressed[:lines, :cols]
 
 
 def GetFrecs(fft):

--- a/emva1288/process/routines.py
+++ b/emva1288/process/routines.py
@@ -142,7 +142,7 @@ def FFT1288(img_, rotate=False, n=1):
     -------
     array : One dimension FFT power spectrum
     '''
-    img = np.ma.copy(img_)
+    img = img_.copy()
     if rotate:
         img = img.transpose()
 

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -53,3 +53,15 @@ def test_highpass_filter():
     # equal
     assert np.allclose(sig_img_filt, img_filt, rtol=0, atol=10e-4)
     assert np.allclose(sig_imgc_filt, imgc_filt, rtol=0, atol=10e-4)
+
+
+def test_FFT1288_masked():
+    """ Make sure the masking happens properly in the fft calculation """
+    rows = 512
+    cols = 128
+    bayer_filter = np.tile([[0, 1], [1, 0]], (rows//2, cols//2))
+    img = np.abs(np.random.random([rows, cols]))
+    # apply column offset to some bottom rows only and make sure we see it in the fft
+    img[128::, ::8] += 10
+    fft = routines.FFT1288(img_=np.ma.array(img, mask=bayer_filter))
+    assert (fft > 1).any()

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -63,5 +63,5 @@ def test_FFT1288_masked():
     img = np.abs(np.random.random([rows, cols]))
     # apply column offset to some bottom rows only and make sure we see it in the fft
     img[128::, ::8] += 10
-    fft = routines.FFT1288(img_=np.ma.array(img, mask=bayer_filter))
+    fft = routines.FFT1288(img=np.ma.array(img, mask=bayer_filter))
     assert (fft > 1).any()


### PR DESCRIPTION
`img = img_line[:][0:cols]` was not slicing to the number of
columns but was slicing the rows in stead. It's now re-written
to use a 2-dim numpy array iso a python list of 1-dim numpy arrays.
This 2-dim numpy array uses the same base array the `img` to save
memory and it is sliced to the correct size before being passed to
code that does the actual FFT calculation.