### PR TITLE
Incluse nyquist

### DIFF
--- a/emva1288/process/routines.py
+++ b/emva1288/process/routines.py
@@ -119,7 +119,7 @@ def GetImgShape(img):
     return rows, cols
 
 
-def FFT1288(img_, rotate=False, n=1):
+def FFT1288(img, rotate=False, n=1):
     '''Compute the FFT emva1288 style
 
     Compute an FFT per line and average the resulting ffts
@@ -142,35 +142,14 @@ def FFT1288(img_, rotate=False, n=1):
     -------
     array : One dimension FFT power spectrum
     '''
-    img = img_.copy()
     if rotate:
         img = img.transpose()
 
-    _rows, cols = GetImgShape(img)
-
     # remove masked entries if img is a masked array
     if isinstance(img, np.ma.masked_array):
-        # use the same ndarray to save memory
-        compressed = np.ma.getdata(img)
-        # the maximum numbers or cols is the shape
-        cols = compressed.shape[1]
-        # keep count of non empty lines
-        lines = 0
-        # compress line by line
-        for line in img:
-            # drop masked data
-            line = line.compressed()
-            # assure the line is not empty
-            if line.size == 0:
-                continue
-            # set the data in the compressed array
-            compressed[lines, :line.size] = line
-            # keep count of non-empty lines
-            lines += 1
-            # keep trac of minimum column size
-            cols = min(cols, line.size)
-        # trim to actual number of lines and columns
-        img = compressed[:lines, :cols]
+        img = _row_wise_compress(img)
+
+    _rows, cols = GetImgShape(img)
 
     # simply perform fft on x axis
     img = np.asfarray(img) - np.mean(img)
@@ -187,6 +166,36 @@ def FFT1288(img_, rotate=False, n=1):
 
     # Return only half of the spectrogram (it is symemtrical)
     return r[: cols // 2]
+
+
+def _row_wise_compress(img):
+    """ Compress masked ndarrays row-by-row
+
+    Empty (fully masked) rows are removed. The number of columns is truncated to the row with the least amount
+    of valid entries.
+    """
+    img = img.copy()
+    # use the same ndarray to save memory
+    compressed = np.ma.getdata(img)
+    # the maximum numbers or cols is the shape
+    cols = compressed.shape[1]
+    # keep count of non empty lines
+    lines = 0
+    # compress line by line
+    for line in img:
+        # drop masked data
+        line = line.compressed()
+        # assure the line is not empty
+        if line.size == 0:
+            continue
+        # set the data in the compressed array
+        compressed[lines, :line.size] = line
+        # keep count of non-empty lines
+        lines += 1
+        # keep trac of minimum column size
+        cols = min(cols, line.size)
+    # trim to actual number of lines and columns
+    return compressed[:lines, :cols]
 
 
 def GetFrecs(fft):

--- a/emva1288/process/routines.py
+++ b/emva1288/process/routines.py
@@ -142,7 +142,7 @@ def FFT1288(img_, rotate=False, n=1):
     -------
     array : One dimension FFT power spectrum
     '''
-    img = np.ma.copy(img_)
+    img = img_.copy()
     if rotate:
         img = img.transpose()
 

--- a/emva1288/process/routines.py
+++ b/emva1288/process/routines.py
@@ -164,8 +164,8 @@ def FFT1288(img, rotate=False, n=1):
     # if the image is the sum of n image, the fft of the average image is
     r /= n ** 2
 
-    # Return only half of the spectrogram (it is symemtrical)
-    return r[: cols // 2]
+    # Return only half of the spectrogram (it is symmetrical)
+    return r[: cols // 2 + 1]
 
 
 def _row_wise_compress(img):

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -53,3 +53,15 @@ def test_highpass_filter():
     # equal
     assert np.allclose(sig_img_filt, img_filt, rtol=0, atol=10e-4)
     assert np.allclose(sig_imgc_filt, imgc_filt, rtol=0, atol=10e-4)
+
+
+def test_FFT1288_masked():
+    """ Make sure the masking happens properly in the fft calculation """
+    rows = 512
+    cols = 128
+    bayer_filter = np.tile([[0, 1], [1, 0]], (rows//2, cols//2))
+    img = np.abs(np.random.random([rows, cols]))
+    # apply column offset to some bottom rows only and make sure we see it in the fft
+    img[128::, ::8] += 10
+    fft = routines.FFT1288(img_=np.ma.array(img, mask=bayer_filter))
+    assert (fft > 1).any()

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -65,3 +65,15 @@ def test_FFT1288_masked():
     img[128::, ::8] += 10
     fft = routines.FFT1288(img=np.ma.array(img, mask=bayer_filter))
     assert (fft > 1).any()
+
+
+def test_FFT1288_at_nyquist():
+    '''Make sure the nyquist freq is also included
+
+    An odd-even offset in the image should show up as a high spike at nyquist
+    '''
+    img = np.random.random([256, 128])
+    img[:, ::2] += 1
+    fft = routines.FFT1288(img_=img)
+    print(fft)
+    assert fft[-1] > 1

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -74,6 +74,6 @@ def test_FFT1288_at_nyquist():
     '''
     img = np.random.random([256, 128])
     img[:, ::2] += 1
-    fft = routines.FFT1288(img_=img)
+    fft = routines.FFT1288(img=img)
     print(fft)
     assert fft[-1] > 1

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -75,5 +75,7 @@ def test_FFT1288_at_nyquist():
     img = np.random.random([256, 128])
     img[:, ::2] += 1
     fft = routines.FFT1288(img=img)
-    print(fft)
+    assert fft[-1] > 1
+    # check if it also works on 127 columns
+    fft = routines.FFT1288(img=np.delete(img, -1, 1))
     assert fft[-1] > 1

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -63,5 +63,5 @@ def test_FFT1288_masked():
     img = np.abs(np.random.random([rows, cols]))
     # apply column offset to some bottom rows only and make sure we see it in the fft
     img[128::, ::8] += 10
-    fft = routines.FFT1288(img_=np.ma.array(img, mask=bayer_filter))
+    fft = routines.FFT1288(img=np.ma.array(img, mask=bayer_filter))
     assert (fft > 1).any()


### PR DESCRIPTION
Make sure we also have the Nyquist frequency in the spectrogram. Up to now only the `number_of_columns // 2` samples where shown in the spectrogram but this excludes the Nyquist frequency itself.

This means we are not showing the max frequency variation in the spectrograms which are odd-even offsets and gains. (with a period of two row or columns).
The plot below shows the horizontal spectrogram of an image filled with random values with odd-even offset added and it plots both `cols // 2` samples and `cols // 2 + 1` samples.

![image](https://user-images.githubusercontent.com/1516890/176177194-0f546fab-fa3a-4fb7-a2d9-8e66bf97499b.png)

The code to generate this image is:
```python
img = np.abs(np.random.random([512, 256]))
rows = img.shape[0]
cols = img.shape[1]

img[::,::2] += 1  # add some odd-even offset

# calulate the fft
img = np.asfarray(img) - np.mean(img)
fft = np.fft.fft(img, axis=1)
fft /= np.sqrt(cols)
fabs = np.real(fft * np.conjugate(fft))
r = np.mean(fabs, axis=0)

# plot both cols // 2 and cols // 2 + 1 samples
plt.figure()
plt.plot(np.linspace(0, cols//2, cols//2)/cols, r[:cols//2], label="odd-even offset / cols//2 samples")
plt.plot(np.linspace(0, cols//2+1, cols//2+1)/cols, r[:cols//2+1], '--', label="odd-even offset / cols//2+1 samples")
plt.yscale("log")
plt.grid()
plt.xlabel("prediods/pixel")
plt.ylabel("relative presence of each cycle")
plt.show()
plt.legend()
plt.show()
```
