### PR TITLE
create test report generation durring CI: fix #166

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   run-tests:
     docker:
-      - image: cimg/python:3.10.2
+      - image: cimg/python:latest
     steps:
       - checkout
       - run:
@@ -15,14 +15,31 @@ jobs:
 
   run-examples:
     docker:
-      - image: cimg/python:3.10.2
+      - image: cimg/python:latest
     steps:
       - checkout
       - run:
           command: pip install --upgrade pip; pip install .[doc]
       - run:
+          # The report example requires a lot of RAM. Since we only want to
+          # check the syntax, we change the parameters for the execution in
+          # the CI so that only little RAM is consumed.
           name: Generate report tex-file
-          command: python doc/examples/sample_report.py
+          command: >
+            echo -e \
+              '#!/bin/bash\n' \
+              'echo -n "Replace the unique line \"${1}\" with \"${2}\"" && ' \
+              'sed -i "/^${1}\\$/{s//${2}/;x;/./{q1};x;h};\\${x;/./{x;q0};x;q1}" doc/examples/sample_report.py && ' \
+              'echo -e "\\033[1;32m Success\\033[0m" && exit 0 || ' \
+              'echo -e "\\033[1;31m Fail\\033[0m" && exit 1' \
+                > ~/.local/bin/update_sample_report.sh;
+            chmod +x ~/.local/bin/update_sample_report.sh;
+            update_sample_report.sh "width = 640" "width = 32";
+            update_sample_report.sh "height = 480" "height = 24";
+            update_sample_report.sh "steps = 50" "steps = 10";
+            set -o xtrace;
+            cat doc/examples/sample_report.py;
+            python doc/examples/sample_report.py
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,25 +21,11 @@ jobs:
       - run:
           command: pip install --upgrade pip; pip install .[doc]
       - run:
-          # The report example requires a lot of RAM. Since we only want to
-          # check the syntax, we change the parameters for the execution in
-          # the CI so that only little RAM is consumed.
+          name: Install CI doc test files
+          command: set -o xtrace; cp .circleci/test_doc_examples/ci_test_*.py doc/examples/
+      - run:
           name: Generate report tex-file
-          command: >
-            echo -e \
-              '#!/bin/bash\n' \
-              'echo -n "Replace the unique line \"${1}\" with \"${2}\"" && ' \
-              'sed -i "/^${1}\\$/{s//${2}/;x;/./{q1};x;h};\\${x;/./{x;q0};x;q1}" doc/examples/sample_report.py && ' \
-              'echo -e "\\033[1;32m Success\\033[0m" && exit 0 || ' \
-              'echo -e "\\033[1;31m Fail\\033[0m" && exit 1' \
-                > ~/.local/bin/update_sample_report.sh;
-            chmod +x ~/.local/bin/update_sample_report.sh;
-            update_sample_report.sh "width = 640" "width = 32";
-            update_sample_report.sh "height = 480" "height = 24";
-            update_sample_report.sh "steps = 50" "steps = 10";
-            set -o xtrace;
-            cat doc/examples/sample_report.py;
-            python doc/examples/sample_report.py
+          command: python doc/examples/ci_test_sample_report.py
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   run-tests:
     docker:
-      - image: cimg/python:latest
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:
@@ -15,7 +15,7 @@ jobs:
 
   run-examples:
     docker:
-      - image: cimg/python:latest
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: pip install --upgrade pip; pip install .[emva1288]
+          command: pip install --upgrade pip; pip install .[doc]
       - run:
           name: Generate report tex-file
           command: python doc/examples/sample_report.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,47 +1,50 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/2.0/configuration-reference
+# https://circleci.com/docs/configuration-reference
 version: 2.1
 
-# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
-# See: https://circleci.com/docs/2.0/orb-intro/
-orbs:
-  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
-  # Orb commands and jobs help you with common scripting around a language/tool
-  # so you dont have to copy and paste it everywhere.
-  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
-  python: circleci/python@1.5.0
-
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  build-and-test: # This is the name of the job, feel free to change it to better match what you're trying to do!
-    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
-    # You can specify an image from Dockerhub or use one of the convenience images from CircleCI's Developer Hub
-    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
-    # The executor is the environment in which the steps below will be executed - below will use a python 3.10.2 container
-    # Change the version below to your required version of python
+  run-tests:
     docker:
       - image: cimg/python:3.10.2
-    # Checkout the code as the first step. This is a dedicated CircleCI step.
-    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
-    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
-    # Then run your tests!
-    # CircleCI will report the results back to your VCS provider.
     steps:
       - checkout
       - run:
           command: pip install --upgrade pip; pip install .[tests]
-          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
-          # pip-dependency-file: test-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
       - run:
-          name: Run tests
-          # This assumes pytest is installed via the install-package step above
+          name: Run unittests
           command: pytest
 
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+  run-examples:
+    docker:
+      - image: cimg/python:3.10.2
+    steps:
+      - checkout
+      - run:
+          command: pip install --upgrade pip; pip install .[emva1288]
+      - run:
+          name: Generate report tex-file
+          command: python doc/examples/sample_report.py
+      - persist_to_workspace:
+          root: .
+          paths:
+            - myreport
+
+  compile-report:
+    docker:
+      - image: texlive/texlive:latest
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Compile report tex-file
+          command: cd myreport; set -o xtrace; ls -laR; cat -n report.tex; latexmk --pdflatex report.tex
+
 workflows:
-  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run.
+  unittests:
     jobs:
-      - build-and-test
+      - run-tests
+  create-report:
+    jobs:
+      - run-examples
+      - compile-report:
+          requires:
+            - run-examples

--- a/.circleci/test_doc_examples/ci_test_sample_report.py
+++ b/.circleci/test_doc_examples/ci_test_sample_report.py
@@ -1,0 +1,23 @@
+import sample_report
+
+from emva1288.camera.dataset_generator import DatasetGenerator
+
+gain = 0.1
+black_level = 29.4
+bit_depth = 12
+steps = 10
+
+dataset_generator = DatasetGenerator(width=32,
+                                     height=24,
+                                     K=gain,
+                                     blackoffset=black_level,
+                                     bit_depth=bit_depth,
+                                     steps=steps,
+                                     exposure_fixed=1000000,
+                                     dark_current_ref=30)
+
+sample_report.main(dataset_descripton_file=dataset_generator.descriptor_path,
+                   gain=gain,
+                   black_level=black_level,
+                   bit_depth=bit_depth,
+                   steps=steps)

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 
 # EXAMPLE FILES #
 ##################
-doc/examples/myreport/
+myreport/
 
 # OS generated files #
 ######################
@@ -62,3 +62,7 @@ tests/logs/*
 ###################
 /.pytest_cache/*
 tests/reports/*
+
+# CI doc examples tests #
+#########################
+/doc/examples/ci_test_*.py

--- a/doc/examples/sample_report.py
+++ b/doc/examples/sample_report.py
@@ -1,80 +1,92 @@
+import emva1288
 from emva1288 import process
 from emva1288 import report
-from emva1288.camera.dataset_generator import DatasetGenerator
 import os
 
-# # Load one test to add it as operation point
-# dir_ = '/home/work/1288/datasets/'
-# fname = 'EMVA1288_ReferenceSet_003_Simulation_12Bit/EMVA1288_Data.txt'
-# fname = os.path.join(dir_, fname)
+def main(dataset_descripton_file,
+         gain,
+         black_level,
+         bit_depth,
+         steps
+         ):
+    # Load the dataset
+    parser = process.ParseEmvaDescriptorFile(dataset_descripton_file)
+    imgs = process.LoadImageData(parser.images)
+    dat = process.Data1288(imgs.data)
 
-# Arguments used for dataset generation and report configuration
-width = 640
-height = 480
-gain = 0.1
-black_level = 29.4
-bit_depth = 12
-steps = 50
+    # Description of the setup
+    setup = report.info_setup()
+    setup['Standard version'] = emva1288.__standard_version__
 
-dataset_generator = DatasetGenerator(width=width,
-                                     height=height,
-                                     K=gain,
-                                     blackoffset=black_level,
-                                     bit_depth=bit_depth,
-                                     steps=steps,
-                                     exposure_fixed=1000000,
-                                     dark_current_ref=30)
-
-fname = dataset_generator.descriptor_path
-
-parser = process.ParseEmvaDescriptorFile(fname)
-imgs = process.LoadImageData(parser.images)
-dat = process.Data1288(imgs.data)
+    # Basic information
+    basic = report.info_basic()
+    basic['vendor'] = 'Simulation'
+    basic['data_type'] = 'Single'
+    basic['sensor_type'] = 'simulated sensor'
+    basic['resolution'] = f'{dat.cols}x{dat.rows}'
+    basic['model'] = 'Simulated camera'
 
 
-# Description of the setup
-setup = report.info_setup()
-setup['Standard version'] = 3.1
+    # Marketing information
+    marketing = report.info_marketing()
+    marketing['watermark'] = 'Example'
 
-# Basic information
-basic = report.info_basic()
-basic['vendor'] = 'Simulation'
-basic['data_type'] = 'Single'
-basic['sensor_type'] = 'simulated sensor'
-basic['resolution'] = f'{width}x{height}'
-basic['model'] = 'Simulated camera'
+    # Initialize the report with the marketing data
+    # Provide a non existent name for the output directory
+    myreport = report.Report1288('myreport',
+                                 marketing=marketing,
+                                 setup=setup,
+                                 basic=basic)
 
+    # Operation point
+    # bit_depth, gain, black_level, exposure_time, wavelength,
+    # temperature, housing_temperature, fpn_correction,
+    # summary_only
 
-# Marketing information
-marketing = report.info_marketing()
-marketing['watermark'] = 'Example'
+    op1 = report.info_op()
+    op1['summary_only'] = False
+    op1['camera_settings']['Gain'] = gain
+    op1['camera_settings']['Black level'] = black_level
+    op1['camera_settings']['Bit depth'] = f'{bit_depth} bits'
+    op1['test_parameters']['Illumination'] = 'Variable with constant exposure time'
+    op1['test_parameters']['Irradiation steps'] = steps
 
-# Initialize the report with the marketing data
-# Provide a non existent name for the output directory
-myreport = report.Report1288('myreport',
-                             marketing=marketing,
-                             setup=setup,
-                             basic=basic)
+    # Add the operation point to the report
+    # we can add as many operation points as we want
+    # we pass the emva1288.Data1288 object to extract automatically all the results
+    # and graphics
+    myreport.add(op1, dat.data)
 
-# Operation point
-# bit_depth, gain, black_level, exposure_time, wavelength,
-# temperature, housing_temperature, fpn_correction,
-# summary_only
+    # Generate the latex files
+    myreport.latex()
 
-op1 = report.info_op()
-op1['summary_only'] = False
-op1['camera_settings']['Gain'] = gain
-op1['camera_settings']['Black level'] = black_level
-op1['camera_settings']['Bit depth'] = f'{bit_depth} bits'
-op1['test_parameters']['Illumination'] = 'Variable with constant \
-exposure time'
-op1['test_parameters']['Irradiation steps'] = steps
+if __name__ == '__main__':
+    # Arguments used for dataset generation and report configuration
+    gain = 0.1
+    black_level = 29.4
+    bit_depth = 12
+    steps = 50
 
-# Add the operation point to the report
-# we can add as many operation points as we want
-# we pass the emva1288.Data1288 object to extract automatically all the results
-# and graphics
-myreport.add(op1, dat.data)
+    # # Alternative 1: Load one test to add it as operation point
+    # dir_ = '/path/to/emva1288/datasets/'
+    # fname = 'EMVA1288_ReferenceSet_003_Simulation_12Bit/EMVA1288_Data.txt'
+    # fname = os.path.join(dir_, fname)
 
-# Generate the latex files
-myreport.latex()
+    # Alternative 2: Generate a new test dataset
+    from emva1288.camera.dataset_generator import DatasetGenerator
+
+    dataset_generator = DatasetGenerator(width=640,
+                                         height=480,
+                                         K=gain,
+                                         blackoffset=black_level,
+                                         bit_depth=bit_depth,
+                                         steps=steps,
+                                         exposure_fixed=1000000,
+                                         dark_current_ref=30)
+    fname = dataset_generator.descriptor_path
+
+    main(dataset_descripton_file=fname,
+         gain=gain,
+         black_level=black_level,
+         bit_depth=bit_depth,
+         steps=steps)

--- a/doc/examples/sample_report.py
+++ b/doc/examples/sample_report.py
@@ -8,8 +8,8 @@ import os
 # fname = 'EMVA1288_ReferenceSet_003_Simulation_12Bit/EMVA1288_Data.txt'
 # fname = os.path.join(dir_, fname)
 
-dataset_generator = DatasetGenerator(width=640,
-                                     height=480,
+dataset_generator = DatasetGenerator(width=160,
+                                     height=120,
                                      K=0.1,
                                      blackoffset=29.4,
                                      bit_depth=12,
@@ -33,7 +33,7 @@ basic = report.info_basic()
 basic['vendor'] = 'Simulation'
 basic['data_type'] = 'Single'
 basic['sensor_type'] = 'simulated sensor'
-basic['resolution'] = '640x480'
+basic['resolution'] = '160x120'
 basic['model'] = 'Simulated camera'
 
 

--- a/doc/examples/sample_report.py
+++ b/doc/examples/sample_report.py
@@ -26,7 +26,6 @@ def main(dataset_descripton_file,
     basic['resolution'] = f'{dat.cols}x{dat.rows}'
     basic['model'] = 'Simulated camera'
 
-
     # Marketing information
     marketing = report.info_marketing()
     marketing['watermark'] = 'Example'

--- a/doc/examples/sample_report.py
+++ b/doc/examples/sample_report.py
@@ -8,12 +8,20 @@ import os
 # fname = 'EMVA1288_ReferenceSet_003_Simulation_12Bit/EMVA1288_Data.txt'
 # fname = os.path.join(dir_, fname)
 
-dataset_generator = DatasetGenerator(width=160,
-                                     height=120,
-                                     K=0.1,
-                                     blackoffset=29.4,
-                                     bit_depth=12,
-                                     steps=50,
+# Arguments used for dataset generation and report configuration
+width = 640
+height = 480
+gain = 0.1
+black_level = 29.4
+bit_depth = 12
+steps = 50
+
+dataset_generator = DatasetGenerator(width=width,
+                                     height=height,
+                                     K=gain,
+                                     blackoffset=black_level,
+                                     bit_depth=bit_depth,
+                                     steps=steps,
                                      exposure_fixed=1000000,
                                      dark_current_ref=30)
 
@@ -33,7 +41,7 @@ basic = report.info_basic()
 basic['vendor'] = 'Simulation'
 basic['data_type'] = 'Single'
 basic['sensor_type'] = 'simulated sensor'
-basic['resolution'] = '160x120'
+basic['resolution'] = f'{width}x{height}'
 basic['model'] = 'Simulated camera'
 
 
@@ -55,12 +63,12 @@ myreport = report.Report1288('myreport',
 
 op1 = report.info_op()
 op1['summary_only'] = False
-op1['camera_settings']['Gain'] = 0.1
-op1['camera_settings']['Black level'] = 29.4
-op1['camera_settings']['Bit depth'] = '12 bits'
+op1['camera_settings']['Gain'] = gain
+op1['camera_settings']['Black level'] = black_level
+op1['camera_settings']['Bit depth'] = f'{bit_depth} bits'
 op1['test_parameters']['Illumination'] = 'Variable with constant \
 exposure time'
-op1['test_parameters']['Irradiation steps'] = 50
+op1['test_parameters']['Irradiation steps'] = steps
 
 # Add the operation point to the report
 # we can add as many operation points as we want

--- a/doc/examples/sample_report.py
+++ b/doc/examples/sample_report.py
@@ -60,6 +60,7 @@ def main(dataset_descripton_file,
     # Generate the latex files
     myreport.latex()
 
+
 if __name__ == '__main__':
     # Arguments used for dataset generation and report configuration
     gain = 0.1

--- a/doc/examples/sample_report.py
+++ b/doc/examples/sample_report.py
@@ -3,6 +3,7 @@ from emva1288 import process
 from emva1288 import report
 import os
 
+
 def main(dataset_descripton_file,
          gain,
          black_level,

--- a/emva1288/report/templates/op.tex
+++ b/emva1288/report/templates/op.tex
@@ -106,7 +106,7 @@
 
 & % %{{ op.results.sensitivity.DR_dB.symbol %}} &
 %{{ '%.1f' % op.results.sensitivity.DR_dB.value %}} &
-%{{ op.results.sensitivity.DR_dB.unit %}}[3mm]
+%{{ op.results.sensitivity.DR_dB.unit %}} \\[3mm]
 
 \multicolumn{3}{l}{\textbf{Spatial Nonuniformities}} \\
 

--- a/emva1288/report/templates/report.tex
+++ b/emva1288/report/templates/report.tex
@@ -7,9 +7,12 @@
 \usepackage{xcolor}
 \usepackage{emvadatasheet}
 \usepackage{lastpage}
-\usepackage[printwatermark]{xwatermark}
 \usepackage{tikz}
 \usepackage{multicol}
+%{ if marketing.watermark %}
+\usepackage[color={red!30}, fontsize=96pt, text={%{{marketing.watermark%}}}]{draftwatermark}
+%{ endif %}
+
 \title{}
 \author{}
 \date{}
@@ -17,14 +20,6 @@
 
 \newcommand{\TheReportSection}{}
 \newcommand{\ReportSection}[1]{\renewcommand{\TheReportSection}{#1}}
-
-%{ if marketing.watermark %}
-\newsavebox\wtmkbox
-\savebox\wtmkbox{\tikz[color=red,opacity=0.3]\node{%{{marketing.watermark%}}};}
-\newwatermark*[
-allpages, angle=45.0, scale=8.0, xpos=-20, ypos=15
-]{\usebox\wtmkbox}
-%{ endif %}
 
 %First marketing cover page
 %{ if cover_page %}


### PR DESCRIPTION
I break down the description of the changes by file. ;-)

### `.circleci/config.yml`

This is the primary change. As requested in the issue, the creation of the report is now tested in addition to the unit tests. Based on this, I can introduce more such 'syntax tests' later.

I have removed the comments from circleci's sample file. I take the position that comments should never be used in source code to explain the programming language. It makes the source code confusing and the explanation is practically always incomplete and/or outdated. Instead I have linked the doc of the circleci YAML dialect at the top.

The `orbs` definition is thrown out, because we do not use that.

I have defined three jobs:

1. `run-tests` installs our `tests` package including its dependencies and then runs the tests. This is identical to the previous pipeline.
2. `run-examples` installs our `emva1288` package including its dependencies and runs `doc/examples/sample_report.py` to generate the tex version of the report. The generated directory is saved. In principle, other samples can also be executed in this job to check them for syntax errors.
3. `compile-report` is executed in the current Docker container of the `texlive` distribution. It loads the saved report folder and uses `latexmk` to generate the PDF file. Like the usual IDEs, `latexmk` repeatedly calls `pdflatex` until the final PDF is generated.

The `unittests` workflow calls the `run-tests` job. The `create-report` workflow calls the `run-examples` and `compile-report` jobs. Thereby `compile-report` has to wait until `run-examples` has finished successfully.

### `doc/examples/sample_report.py`

I reduced the image resolution for the sample report generation from 640x480 to 160x120.

The 640x480 requires 13.4 GB of RAM. I don't want to impose that on the CI or the end user in an example. In both cases we don't know how potent the hardware is and the examples should work by default. The 160x120 still requires 900 MB of RAM.

If I find time, I'll take a look to see if that can be reduced.

If reducing the resolution causes problems with the content, please let me know.

### `emva1288/report/templates/op.tex`

That's the bug @zhaoyutong43210 already mentioned in [#166](https://github.com/EMVA1288/emva1288/pull/163#issuecomment-1243905583). This is exactly the kind of bug the new pipeline is supposed to detect, and it did. ;-)

### `emva1288/report/templates/report.tex`

I have replaced the `xwatermark` latex package with `draftwatermark`. `xwatermark` does not work with most Tex distributions after 2020 and should not be used anymore. (See https://tex.stackexchange.com/questions/634973/extra-endgroup-begindocument-frustrations#answer-635421)
