### PR TITLE
run CI on python 3.8 and on current python #168

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,10 @@
 version: 2.1
 
 jobs:
-  run-tests:
+  run-tests-3-10:
     docker:
       - image: cimg/python:3.10
-    steps:
+    steps: &run-tests
       - checkout
       - run:
           command: pip install --upgrade pip; pip install .[tests]
@@ -13,10 +13,15 @@ jobs:
           name: Run unittests
           command: pytest
 
-  run-examples:
+  run-tests-3-8:
+    docker:
+      - image: cimg/python:3.8
+    steps: *run-tests
+
+  run-examples-3-10:
     docker:
       - image: cimg/python:3.10
-    steps:
+    steps: &run-examples
       - checkout
       - run:
           command: pip install --upgrade pip; pip install .[doc]
@@ -31,7 +36,12 @@ jobs:
           paths:
             - myreport
 
-  compile-report:
+  run-examples-3-8:
+    docker:
+      - image: cimg/python:3.8
+    steps: *run-examples
+
+  compile-report-3-10:
     docker:
       - image: texlive/texlive:latest
     steps:
@@ -42,12 +52,14 @@ jobs:
           command: cd myreport; set -o xtrace; ls -laR; cat -n report.tex; latexmk --pdflatex report.tex
 
 workflows:
-  unittests:
+  python-3-10:
     jobs:
-      - run-tests
-  create-report:
-    jobs:
-      - run-examples
-      - compile-report:
+      - run-tests-3-10
+      - run-examples-3-10
+      - compile-report-3-10:
           requires:
-            - run-examples
+            - run-examples-3-10
+  python-3-8:
+    jobs:
+      - run-tests-3-8
+      - run-examples-3-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   run-tests-3-10:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
     steps: &run-tests
       - checkout
       - run:
@@ -20,7 +20,7 @@ jobs:
 
   run-examples-3-10:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
     steps: &run-examples
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 jobs:
-  run-tests-3-10:
+  run-tests-latest-version:
     docker:
       - image: cimg/python:3.11
     steps: &run-tests
@@ -13,12 +13,12 @@ jobs:
           name: Run unittests
           command: pytest
 
-  run-tests-3-8:
+  run-tests-min-version:
     docker:
       - image: cimg/python:3.8
     steps: *run-tests
 
-  run-examples-3-10:
+  run-examples-latest-version:
     docker:
       - image: cimg/python:3.11
     steps: &run-examples
@@ -36,12 +36,12 @@ jobs:
           paths:
             - myreport
 
-  run-examples-3-8:
+  run-examples-min-version:
     docker:
       - image: cimg/python:3.8
     steps: *run-examples
 
-  compile-report-3-10:
+  compile-report-latest-version:
     docker:
       - image: texlive/texlive:latest
     steps:
@@ -52,14 +52,14 @@ jobs:
           command: cd myreport; set -o xtrace; ls -laR; cat -n report.tex; latexmk --pdflatex report.tex
 
 workflows:
-  python-3-10:
+  python-latest-version:
     jobs:
-      - run-tests-3-10
-      - run-examples-3-10
-      - compile-report-3-10:
+      - run-tests-latest-version
+      - run-examples-latest-version
+      - compile-report-latest-version:
           requires:
-            - run-examples-3-10
-  python-3-8:
+            - run-examples-latest-version
+  python-min-version:
     jobs:
-      - run-tests-3-8
-      - run-examples-3-8
+      - run-tests-min-version
+      - run-examples-min-version

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ license =  GNU General Public License v3.0
 license_files = LICENSE
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.8
 author = Federico Ariza
 author_email = ariza.federico@gmail.com
 url = https://github.com/EMVA1288/emva1288


### PR DESCRIPTION
I updated the setup to require at least Python 3.8 and adjusted the CI to run all its stuff on 3.8 and on 3.10 (current version).