### PR TITLE
Updates for v4.0

### DIFF
--- a/emva1288/process/data.py
+++ b/emva1288/process/data.py
@@ -84,8 +84,10 @@ class Data1288(object):
                time and photon count,
                *'u_ydark'*: the array of the mean digital dark value
                for each exposure time
-               and *'s2_ydark'*: the
-               array of the digital dark value variance for each exposure time.
+               *'s2_ydark'*: the
+               array of the digital dark value variance for each exposure time
+               and *'diff_u_y'*: the difference of the mean values of the images
+               for each exposure time.
 
         Raises
         ------
@@ -106,6 +108,7 @@ class Data1288(object):
         s2_y = []
         u_ydark = []
         s2_ydark = []
+        diff_u_y = []
 
         for t in exposures:
             # photons is a list of photon counts
@@ -129,6 +132,7 @@ class Data1288(object):
                 d = self._get_temporal_data(data[t][p])
                 u_y.append(d['mean'])
                 s2_y.append(d['var'] - d['dmean'])
+                diff_u_y.append(data[t][p]['dmean'])    # we need to use the raw difference here
 
         # Append all data to temporal dict
         temporal['u_p'] = np.asarray(u_p)
@@ -136,6 +140,7 @@ class Data1288(object):
         temporal['s2_y'] = np.asarray(s2_y)
         temporal['u_ydark'] = np.asarray(u_ydark)
         temporal['s2_ydark'] = np.asarray(s2_ydark)
+        temporal['diff_u_y'] = np.asarray(diff_u_y)
 
         # In case we have only one exposure, we need arrays with the
         # same length as the up

--- a/emva1288/process/data.py
+++ b/emva1288/process/data.py
@@ -54,8 +54,10 @@ class Data1288(object):
         self.data = {}
         self.data['temporal'] = self._get_temporal(data['temporal'])
         self.data['spatial'] = self._get_spatial(data['spatial'])
+        self.data['darkcurrent'] =self._get_temporal(data['darkcurrent'], True)
+        print()
 
-    def _get_temporal(self, data):
+    def _get_temporal(self, data, dark_only=False):
         """Fill the temporal dict, with the stuff that we need.
         Compute the averages and variances from the sums (sum and pvar)
 
@@ -118,7 +120,7 @@ class Data1288(object):
             if 0.0 not in photons:
                 raise ValueError('Every exposure point must have a 0.0 photon')
 
-            if len(photons) < 2:
+            if len(photons) < 2 and not dark_only:
                 raise ValueError('There must be at least one bright photon')
 
             # get data for dark image

--- a/emva1288/process/loader.py
+++ b/emva1288/process/loader.py
@@ -53,7 +53,7 @@ class LoadImageData(object):
         fload_kwargs : dict, optional
                        The kwargs dictionary for the fload function.
         """
-        self.data = {'temporal': {}, 'spatial': {}}
+        self.data = {'temporal': {}, 'spatial': {}, 'darkcurrent': {}}
         self._fload = fload
         self._fload_args = fload_args
         self._fload_kwargs = fload_kwargs
@@ -72,7 +72,7 @@ class LoadImageData(object):
         the images and fills the temporal and spatial dicts
         """
         # iterate over the kind
-        for kind in ('temporal', 'spatial'):
+        for kind in ('temporal', 'spatial', 'darkcurrent'):
             exposures = set(images[kind].keys())
 
             # iterate over the exposure times for each kind
@@ -85,9 +85,10 @@ class LoadImageData(object):
                     # image with a 0 photon count.
                     raise ValueError('Every exposure must have a 0.0 photons'
                                      ' for dark information')
-                if len(photon_counts) < 2:
+                if len(photon_counts) < 2 and kind != "darkcurrent":
                     # Every exposure time should have at least one dark image
                     # and one bright image.
+                    # NOTE: We can allow only dark values for dark current measurement
                     raise ValueError('All exposure must have at least 2 points'
                                      ' one dark and one bright')
 

--- a/emva1288/process/parser.py
+++ b/emva1288/process/parser.py
@@ -49,7 +49,7 @@ class ParseEmvaDescriptorFile(object):
         self.format = {}  # bits, witdth, height
         self.version = None
         self.images = {'temporal': {},
-                       'darkcurrent' : {},
+                       'darkcurrent': {},
                        'spatial': {}}
 
         logging.basicConfig()

--- a/emva1288/process/plotting.py
+++ b/emva1288/process/plotting.py
@@ -194,6 +194,29 @@ class PlotUyDark(Emva1288Plot):
         self.set_legend(ax)
 
 
+class PlotStabilityCheck(Emva1288Plot):
+    ''' Create the stability check plot '''
+    name = 'Stability Check'
+    xlabel = r'gray value [DN]'
+    ylabel = r'difference/std gray value [DN]'
+
+    def plot(self, test):
+        ax = self.ax
+
+        X = test.temporal['u_y'] - test.temporal['u_ydark']
+        Y1 = np.sqrt(test.temporal['s2_y'])
+        Y2 = test.temporal['diff_u_y']
+        ax.plot(X, Y1,
+                label='Std',
+                gid='%d:std' % test.id)
+        ax.plot(X, Y2,
+                label='Difference',
+                marker='.',
+                ls=' ',
+                gid='%d:difference' % test.id)
+        self.set_legend(ax)
+
+
 class PlotPTC(Emva1288Plot):
     '''Create Photon Transfer plot'''
 
@@ -792,6 +815,7 @@ class PlotVerticalProfile(ProfileBase):
 
 EVMA1288plots = [PlotPTC,
                  PlotSNR,
+                 PlotStabilityCheck,
                  PlotSensitivity,
                  PlotUyDark,
                  PlotLinearity,
@@ -812,6 +836,7 @@ EVMA1288plots = [PlotPTC,
 
     - :class:`~emva1288.process.plotting.PlotPTC`
     - :class:`~emva1288.process.plotting.PlotSNR`
+    - :class:`~emva1288.process.plotting.PlotStabilityCheck`
     - :class:`~emva1288.process.plotting.PlotSensitivity`
     - :class:`~emva1288.process.plotting.PlotUyDark`
     - :class:`~emva1288.process.plotting.PlotLinearity`

--- a/emva1288/process/plotting.py
+++ b/emva1288/process/plotting.py
@@ -207,22 +207,23 @@ class PlotUyDarkCurrent(Emva1288Plot):
         else:
             data = test.temporal
 
-        X = data['texp']
+        if test.dark_current_fit_mean() is not np.nan:
+            X = data['texp']
 
-        ax.plot(X,
-                data['u_ydark'],
-                marker='o',
-                markersize=5,
-                label='Data',
-                gid='%d:data' % test.id)
-        ax.plot(X,
-                test.dark_current_fit_mean()['fit_slope'] *
-                X + test.dark_current_fit_mean()['fit_offset'],
-                linestyle='--',
-                label='Fit',
-                gid='%d:fit' % test.id)
-        ax.ticklabel_format(axis='x', style='sci', scilimits=(1, 4))
-        self.set_legend(ax)
+            ax.plot(X,
+                    data['u_ydark'],
+                    marker='o',
+                    markersize=5,
+                    label='Data',
+                    gid='%d:data' % test.id)
+            ax.plot(X,
+                    test.dark_current_fit_mean()['fit_slope'] *
+                    X + test.dark_current_fit_mean()['fit_offset'],
+                    linestyle='--',
+                    label='Fit',
+                    gid='%d:fit' % test.id)
+            ax.ticklabel_format(axis='x', style='sci', scilimits=(1, 4))
+            self.set_legend(ax)
 
 class PlotVaryDarkCurrent(Emva1288Plot):
     name = 'Dark Current From Variance'
@@ -238,22 +239,23 @@ class PlotVaryDarkCurrent(Emva1288Plot):
         else:
             data = test.temporal
 
-        X = data['texp']
+        if test.dark_current_fit_var() is not np.nan:
+            X = data['texp']
 
-        ax.plot(X,
-                data['s2_ydark'],
-                marker='o',
-                markersize=5,
-                label='Data',
-                gid='%d:data' % test.id)
-        ax.plot(X,
-                test.dark_current_fit_var()['fit_slope'] *
-                X + test.dark_current_fit_var()['fit_offset'],
-                linestyle='--',
-                label='Fit',
-                gid='%d:fit' % test.id)
-        ax.ticklabel_format(axis='x', style='sci', scilimits=(1, 4))
-        self.set_legend(ax)
+            ax.plot(X,
+                    data['s2_ydark'],
+                    marker='o',
+                    markersize=5,
+                    label='Data',
+                    gid='%d:data' % test.id)
+            ax.plot(X,
+                    test.dark_current_fit_var()['fit_slope'] *
+                    X + test.dark_current_fit_var()['fit_offset'],
+                    linestyle='--',
+                    label='Fit',
+                    gid='%d:fit' % test.id)
+            ax.ticklabel_format(axis='x', style='sci', scilimits=(1, 4))
+            self.set_legend(ax)
 
 
 class PlotStabilityCheck(Emva1288Plot):

--- a/emva1288/process/plotting.py
+++ b/emva1288/process/plotting.py
@@ -194,6 +194,68 @@ class PlotUyDark(Emva1288Plot):
         self.set_legend(ax)
 
 
+class PlotUyDarkCurrent(Emva1288Plot):
+    name = 'Dark Current From Mean'
+    xlabel = 'exposure time [ns]'
+    ylabel = r'$\mu_{y.dark}$ [DN]'
+
+    def plot(self, test):
+        ax = self.ax
+
+        if len(test.darkcurrent['texp']) > 2:
+            data = test.darkcurrent
+        else:
+            data = test.temporal
+
+        X = data['texp']
+
+        ax.plot(X,
+                data['u_ydark'],
+                marker='o',
+                markersize=5,
+                label='Data',
+                gid='%d:data' % test.id)
+        ax.plot(X,
+                test.dark_current_fit_mean()['fit_slope'] *
+                X + test.dark_current_fit_mean()['fit_offset'],
+                linestyle='--',
+                label='Fit',
+                gid='%d:fit' % test.id)
+        ax.ticklabel_format(axis='x', style='sci', scilimits=(1, 4))
+        self.set_legend(ax)
+
+class PlotVaryDarkCurrent(Emva1288Plot):
+    name = 'Dark Current From Variance'
+    xlabel = 'exposure time [ns]'
+    ylabel = r'$\sigma^2_{y.dark}$ [DN$^2$]'
+
+
+    def plot(self, test):
+        ax = self.ax
+
+        if len(test.darkcurrent['texp']) > 2:
+            data = test.darkcurrent
+        else:
+            data = test.temporal
+
+        X = data['texp']
+
+        ax.plot(X,
+                data['s2_ydark'],
+                marker='o',
+                markersize=5,
+                label='Data',
+                gid='%d:data' % test.id)
+        ax.plot(X,
+                test.dark_current_fit_var()['fit_slope'] *
+                X + test.dark_current_fit_var()['fit_offset'],
+                linestyle='--',
+                label='Fit',
+                gid='%d:fit' % test.id)
+        ax.ticklabel_format(axis='x', style='sci', scilimits=(1, 4))
+        self.set_legend(ax)
+
+
 class PlotStabilityCheck(Emva1288Plot):
     ''' Create the stability check plot '''
     name = 'Stability Check'
@@ -820,6 +882,8 @@ EVMA1288plots = [PlotPTC,
                  PlotUyDark,
                  PlotLinearity,
                  PlotDeviationLinearity,
+                 PlotUyDarkCurrent,
+                 PlotVaryDarkCurrent,
                  PlotHorizontalSpectrogramPRNU,
                  PlotHorizontalSpectrogramDSNU,
                  PlotVerticalSpectrogramPRNU,
@@ -841,6 +905,8 @@ EVMA1288plots = [PlotPTC,
     - :class:`~emva1288.process.plotting.PlotUyDark`
     - :class:`~emva1288.process.plotting.PlotLinearity`
     - :class:`~emva1288.process.plotting.PlotDeviationLinearity`
+    - :Class:`~emva1288.process.plotting.PlotUyDarkCurrent`
+    - :Class:`~emva1288.process.plotting.PlotVaryDarkCurrent`
     - :class:`~emva1288.process.plotting.PlotHorizontalSpectrogramPRNU`
     - :class:`~emva1288.process.plotting.PlotHorizontalSpectrogramDSNU`
     - :class:`~emva1288.process.plotting.PlotVerticalSpectrogramPRNU`

--- a/emva1288/process/results.py
+++ b/emva1288/process/results.py
@@ -530,6 +530,8 @@ class Results1288(object):
                  relative deviation.
                - *'linearity_error_max'* : The maximal value of the
                  relative deviation.
+               - *'linearity_error_mean'* : In version >= 4.0 the computation
+                 of LE was changed. The v >= 4.0 is represented here
         """
         Y = self.temporal['u_y'] - self.temporal['u_ydark']
         X = self.temporal['u_p']
@@ -563,8 +565,9 @@ class Results1288(object):
         lin['fit_slope'] = a
         lin['fit_offset'] = b
         lin['relative_deviation'] = dev
-        lin['linearity_error_min'] = np.min(dev[imin: imax])
-        lin['linearity_error_max'] = np.max(dev[imin: imax])
+        lin['linearity_error_min'] = np.min(dev[imin: imax])    # deprecated
+        lin['linearity_error_max'] = np.max(dev[imin: imax])    # deprecated
+        lin['linearity_error_mean'] = np.mean(np.abs(dev))
 
         return lin
 
@@ -574,7 +577,7 @@ class Results1288(object):
 
         .. emva1288::
             :Section: linearity
-            :Short: Min Linearity error
+            :Short: Min Linearity error (deprecated)
             :Symbol: $LE_{min}$
             :Unit: \%
             :LatexName: LEMin
@@ -588,13 +591,27 @@ class Results1288(object):
 
         .. emva1288::
             :Section: linearity
-            :Short: Max Linearity error
+            :Short: Max Linearity error (deprecated)
             :Symbol: $LE_{max}$
             :Unit: \%
             :LatexName: LEMax
         """
 
         return self.linearity()['linearity_error_max']
+
+    @property
+    def LE_mean(self):
+        r"""Linearity error.
+
+        .. emva1288::
+            :Section: linearity
+            :Short: Linearity error
+            :Symbol: $LE$
+            :Unit: \%
+            :LatexName: LEMean
+        """
+
+        return self.linearity()['linearity_error_mean']
 
     @property
     def u_I_var_DN(self):

--- a/emva1288/process/results.py
+++ b/emva1288/process/results.py
@@ -566,8 +566,8 @@ class Results1288(object):
         lin['fit_slope'] = a
         lin['fit_offset'] = b
         lin['relative_deviation'] = dev
-        lin['linearity_error_min'] = np.min(dev[imin: imax])    # deprecated
-        lin['linearity_error_max'] = np.max(dev[imin: imax])    # deprecated
+        lin['linearity_error_min'] = np.min(dev[imin: imax])  # deprecated
+        lin['linearity_error_max'] = np.max(dev[imin: imax])  # deprecated
         lin['linearity_error_mean'] = np.mean(np.abs(dev))
 
         return lin
@@ -616,13 +616,16 @@ class Results1288(object):
 
     def dark_current_fit_var(self):
         r"""Dark Current fit from variance.
-        The keys are:
 
-        - *'fit_slope'* : The slope of the linear fit.
-        - *'fit_offset'* : The offset of the fit.
-        - *'error'*: The error between fit and actual values
+        Returns
+        -------
+        dict : Linearity dictionary.
+               The keys are:
+                - *'fit_slope'* : The slope of the linear fit.
+                - *'fit_offset'* : The offset of the fit.
+                - *'error'*: The error between fit and actual values
         """
-        if len(np.unique(self.darkcurrent['texp'])) > 2:
+        if ('texp' in self.darkcurrent) and (len(self.darkcurrent['texp']) > 2):
             darkcurrent = self.darkcurrent
         else:
             darkcurrent = self.temporal
@@ -632,11 +635,11 @@ class Results1288(object):
 
         fit, _error = routines.LinearB(darkcurrent['texp'],
                                        darkcurrent['s2_ydark'])
-        return  {
-                    'fit_slope': fit[0],
-                    'fit_offset': fit[1],
-                    'error': _error
-                }
+        return {
+            'fit_slope': fit[0],
+            'fit_offset': fit[1],
+            'error': _error
+        }
 
     @property
     def u_I_var_DN(self):
@@ -655,7 +658,7 @@ class Results1288(object):
         """
         dc = self.dark_current_fit_var()
 
-        if dc['fit_slope'] < 0:
+        if (dc is np.nan) or (dc['fit_slope'] < 0):
             return np.nan
         # Multiply by 10^9 because exposure times are in nanoseconds
         return dc['fit_slope'] / self.K * 1e9
@@ -683,13 +686,16 @@ class Results1288(object):
 
     def dark_current_fit_mean(self):
         r"""Dark Current fit from mean.
-        The keys are:
 
-        - *'fit_slope'* : The slope of the linear fit.
-        - *'fit_offset'* : The offset of the fit.
-        - *'error'*: The error between fit and actual values
+        Returns
+        -------
+        dict : Linearity dictionary.
+               The keys are:
+                - *'fit_slope'* : The slope of the linear fit.
+                - *'fit_offset'* : The offset of the fit.
+                - *'error'*: The error between fit and actual values
         """
-        if len(np.unique(self.darkcurrent['texp'])) > 2:
+        if ('texp' in self.darkcurrent) and (len(self.darkcurrent['texp']) > 2):
             darkcurrent = self.darkcurrent
         else:
             darkcurrent = self.temporal
@@ -699,11 +705,11 @@ class Results1288(object):
 
         fit, _error = routines.LinearB(darkcurrent['texp'],
                                        darkcurrent['u_ydark'])
-        return  {
-                    'fit_slope': fit[0],
-                    'fit_offset': fit[1],
-                    'error': _error
-                }
+        return {
+            'fit_slope': fit[0],
+            'fit_offset': fit[1],
+            'error': _error
+        }
 
     @property
     def u_I_mean_DN(self):
@@ -720,7 +726,7 @@ class Results1288(object):
             :Unit: $DN/s$
         """
         dc = self.dark_current_fit_mean()
-        if dc['fit_slope'] < 0:
+        if dc is np.nan:
             return np.nan
         # Multiply by 10 ^ 9 because exposure time in nanoseconds
         return dc['fit_slope'] * (10 ** 9)
@@ -959,7 +965,7 @@ class Results1288(object):
         M = self.spatial['M']
         N = self.spatial['N']
         para = M * N / (M * N - M - N)
-        s_y_pixel = para*(self.s_2_y - self.s_2_y_cav - self.s_2_y_rav)
+        s_y_pixel = para * (self.s_2_y - self.s_2_y_cav - self.s_2_y_rav)
         return s_y_pixel
 
     @property
@@ -975,7 +981,7 @@ class Results1288(object):
         M = self.spatial['M_dark']
         N = self.spatial['N_dark']
         para = M * N / (M * N - M - N)
-        s_2_y_pixel_dark = para*(self.s_2_y_dark - self.s_2_y_cav_dark - self.s_2_y_rav_dark)
+        s_2_y_pixel_dark = para * (self.s_2_y_dark - self.s_2_y_cav_dark - self.s_2_y_rav_dark)
         return s_2_y_pixel_dark
 
     @property

--- a/emva1288/report/report.py
+++ b/emva1288/report/report.py
@@ -312,18 +312,26 @@ class Report1288(object):
     def _report(self):
         # Generate the report contents
         report = self.renderer.get_template('report.tex')
-        return report.render(marketing=self.marketing,
+        the_render = report.render(marketing=self.marketing,
                              basic=self.basic,
                              setup=self.setup,
                              operation_points=self.ops,
                              cover_page=self.cover_page)
+        return the_render
+        #return report.render(marketing=self.marketing,
+        #                     basic=self.basic,
+        #                     setup=self.setup,
+        #                     operation_points=self.ops,
+        #                     cover_page=self.cover_page)
 
     def latex(self):
         """Generate report latex files.
         """
 
         self._write_file('emvadatasheet.sty', self._stylesheet())
-        self._write_file('report.tex', self._report())
+        the_report = self._report()
+        self._write_file('report.tex', the_report)
+        #self._write_file('report.tex', self._report())
 
     def _results(self, data):
         return Results1288(data)

--- a/emva1288/report/report.py
+++ b/emva1288/report/report.py
@@ -334,7 +334,10 @@ class Report1288(object):
         #self._write_file('report.tex', self._report())
 
     def _results(self, data):
-        return Results1288(data)
+        pixel_area = None
+        if self.basic['pixel_size']:
+            pixel_area = self.basic['pixel_size']
+        return Results1288(data, pixel_area)
 
     def _plots(self, results, id_):
         """Create the plots for the report.

--- a/emva1288/report/templates/op.tex
+++ b/emva1288/report/templates/op.tex
@@ -193,6 +193,14 @@
 \vfill
 \newpage
 \begin{center}
+\includegraphics[height=0.45\textheight,keepaspectratio]{%{{ op.plots.PlotUyDarkCurrent %}}}
+\end{center}
+\begin{center}
+\includegraphics[height=0.45\textheight,keepaspectratio]{%{{ op.plots.PlotVaryDarkCurrent %}}}
+\end{center}
+\vfill
+\newpage
+\begin{center}
 \includegraphics[height=0.45\textheight,keepaspectratio]{%{{ op.plots.PlotHorizontalSpectrogramPRNU %}}}
 \end{center}
 \begin{center}

--- a/emva1288/report/templates/op.tex
+++ b/emva1288/report/templates/op.tex
@@ -144,13 +144,9 @@
 
 \multicolumn{3}{l}{\textbf{Linearity error}} \\
 
-%{{ op.results.linearity.LE_min.symbol %}} &
-%{{ '%.3f' % op.results.linearity.LE_min.value %}} &
-%{{ op.results.linearity.LE_min.unit %}} \\
-
-%{{ op.results.linearity.LE_max.symbol %}} &
-%{{ '%.3f' % op.results.linearity.LE_max.value %}} &
-%{{ op.results.linearity.LE_max.unit %}} \\[3mm]
+%{{ op.results.linearity.LE_mean.symbol %}} &
+%{{ '%.3f' % op.results.linearity.LE_mean.value %}} &
+%{{ op.results.linearity.LE_mean.unit %}} \\[3mm]
 
 \multicolumn{3}{l}{\textbf{Dark current}} \\
 
@@ -175,6 +171,10 @@
 
 %{ if not op.summary_only %}
 %Extra plots
+\newpage
+\begin{center}
+\includegraphics[height=0.45\textheight,keepaspectratio]{%{{ op.plots.PlotStabilityCheck %}}}
+\end{center}
 \newpage
 \begin{center}
 \includegraphics[height=0.45\textheight,keepaspectratio]{%{{ op.plots.PlotSensitivity %}}}

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -64,8 +64,8 @@ def test_sensitivity(results):
 def test_dark_current(results):
     dataset, parser, loader, data, results = results
     # Test that dark current is actually retrieved from both methods
-    assert dataset.cam._dark_current_ref == pytest.approx(results.u_I_mean, abs=5)
-    assert dataset.cam._dark_current_ref == pytest.approx(results.u_I_var, abs=10)
+    assert dataset.cam._dark_current_ref == pytest.approx(results.u_I_mean['slope'], abs=5)
+    assert dataset.cam._dark_current_ref == pytest.approx(results.u_I_var['slope'], abs=10)
 
 
 def test_saturation(results):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -28,8 +28,8 @@ def test_properties(results):
     # Test that EMVA values are float and positive
     for a in ('s2q', 'R', 'K', 'QE', 'sigma_y_dark', 'sigma_d', 'u_p_min',
               'u_p_min_area', 'u_e_min', 'u_e_min_area', 'u_p_sat',
-              'u_p_sat_area', 'u_e_sat', 'SNR_max', 'DR', 'LE_min',
-              'LE_max', 'u_I_var', 'u_I_mean', 'sigma_2_y_stack',
+              'u_p_sat_area', 'u_e_sat', 'SNR_max', 'DR', 'LE_mean',
+              'u_I_var', 'u_I_mean', 'sigma_2_y_stack',
               'sigma_2_y_stack_dark', 's_2_y_measured', 's_2_y',
               's_2_y_dark', 'DSNU1288', 'PRNU1288'):
         value = getattr(results, a)
@@ -38,7 +38,7 @@ def test_properties(results):
             assert a in results.results
         # except for linearity errors and dark currents,
         # everything always should be positive
-        if a not in ('LE_min', 'LE_max') and value is not np.nan:
+        if a not in ('LE_mean') and value is not np.nan:
             assert value >= 0.0
 
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -64,8 +64,8 @@ def test_sensitivity(results):
 def test_dark_current(results):
     dataset, parser, loader, data, results = results
     # Test that dark current is actually retrieved from both methods
-    assert dataset.cam._dark_current_ref == pytest.approx(results.u_I_mean['slope'], abs=5)
-    assert dataset.cam._dark_current_ref == pytest.approx(results.u_I_var['slope'], abs=10)
+    assert dataset.cam._dark_current_ref == pytest.approx(results.u_I_mean, abs=5)
+    assert dataset.cam._dark_current_ref == pytest.approx(results.u_I_var, abs=10)
 
 
 def test_saturation(results):
@@ -126,7 +126,8 @@ def test_DSNU(results):
                         'avg_var': 0.002,
                         'avg_mean': 1600,
                         'avg_var_cav': 0.01,
-                        'avg_var_rav': 0.01}}
+                        'avg_var_rav': 0.01},
+            'darkcurrent': {}}
     results = Results1288(data)
     # Test that DSNU is sqrt(s2_ydark) / gain
     assert results.DSNU1288 == np.sqrt(results.s_2_y_dark) / results.K
@@ -181,7 +182,8 @@ def test_results_without_pixel_area(data):
 def test_nans():
     # Test that less than 2 texp will yield a NaN for u_I_mean
     data = {'temporal': {'texp': [0, 1]},
-            'spatial': {}}
+            'spatial': {},
+            'darkcurrent': {}}
     r = Results1288(data)
     assert r.u_I_mean is np.nan
 


### PR DESCRIPTION
I added some stuff to be more compliant with v4.0 of the standard:

- LE_min and LE_max was replaced by LE in the report
- Stability check was added as plot
- Additional run for dark-current measurement was added (allowing you to use longer exposure times with fewer points). I tried to upload a respective dataset, but the data limit is already reached.
The data describing dark current would look like this in the emva1288.txt:
> # DarkCurrent run with 6 images
> dc 10000.0
> i DarkCurrent/Img_10-0.png
> i DarkCurrent/Img_10-1.png
> dc 200008000.0
> i DarkCurrent/Img_200008-0.png
> i DarkCurrent/Img_200008-1.png
> dc 400006000.0
> i DarkCurrent/Img_400006-0.png
> i DarkCurrent/Img_400006-1.png
> dc 600004000.0
> i DarkCurrent/Img_600004-0.png
> i DarkCurrent/Img_600004-1.png
> dc 800002000.0
> i DarkCurrent/Img_800002-0.png
> i DarkCurrent/Img_800002-1.png
> dc 1000000000.0
> i DarkCurrent/Img_1000000-0.png
> i DarkCurrent/Img_1000000-1.png

- Small adjustments to the tests to still work.